### PR TITLE
tab (or content script) <-> webextension iframe communication using MessageChannel WebAPI

### DIFF
--- a/contentscript.js
+++ b/contentscript.js
@@ -8,7 +8,6 @@ function initToolbar() {
   iframe.setAttribute("style", "position: fixed; top: 0; left: 0; z-index: 10000; width: 100%; height: auto;");
   document.body.appendChild(iframe);
   console.log('Iframe injected in the page');
-  iframe.contentWindow['test'] = window.performance;
 
   return toolbarUI = {
     iframe: iframe, visible: true
@@ -27,8 +26,36 @@ function toggleToolbar(toolbarUI) {
 
 // Handle messages from the add-on background page (only in top level iframes)
 if (window.parent === window) {
+  window.addEventListener("message", function (event) {
+    console.log("window postMessage", event);
+
+    if (event.data == "connect-perfomance-toolbar") {
+      console.log("content script received and setup messagechannel port");
+
+      let [port] = event.ports;
+      port.onmessage = function(event) {
+        console.log("content script received a port message", event);
+        if (event.data == "scan") {
+          // send an updated data set
+          port.postMessage({
+            JSONPerformance: JSON.stringify(window.performance),
+          });
+        }
+      };
+
+      // send an initial data set
+      port.postMessage({
+        JSONPerformance: JSON.stringify({
+          message: "click scan to send a real data set"
+        })
+      });
+
+    } else {
+      console.error("Unrecognized postMessage", event.data);
+    }
+  });
+
   chrome.runtime.onMessage.addListener(function (msg) {
-    console.log(msg)
     if (msg === "toggle-in-page-toolbar") {
       if (toolbarUI) {
         toggleToolbar(toolbarUI);
@@ -38,14 +65,3 @@ if (window.parent === window) {
     }
   });
 }
-
-window.addEventListener("message", function (event) {
-  if (event.data.direction && event.data.direction === "window-performance-iframe") {
-    console.log('Sending to the background js from the page the window.performance object');
-    chrome.runtime.sendMessage({
-      direction: "window-performance-page",
-      message: window.performance
-    });
-    
-  }
-});

--- a/toolbar/ui.html
+++ b/toolbar/ui.html
@@ -7,6 +7,8 @@
   <body>
     <span>
       <span id="title">Click to scan -></span>
+      <pre>
+      </pre>
     </span>
     <button id="scan">Scan</button>
     <script src="ui.js">

--- a/toolbar/ui.js
+++ b/toolbar/ui.js
@@ -1,26 +1,16 @@
-// Handle click events on the toolbar button.
-document.querySelector("#scan").addEventListener("click", function () {
-  console.log('Asking to the page from iframe for the window.performance object');
-  window.parent.postMessage({
-    direction: "window-performance-iframe",
-    message: "Asking for performance"
-  }, '*');
-  console.log(window.test)
-});
+let {port1, port2} = new MessageChannel();
 
-
-window.addEventListener("message", function (event) {
-  console.log(event)
-  if (event.data.direction && event.data.direction === "window-performance-page") {
-    console.log(event.data.message)
-
-//  var resources = window.parent.performance.getEntriesByType("resource");
-//  resources.forEach(function (resource) {
-//    console.log(resource.name);
-//  });
+port1.onmessage = (event) => {
+  if (event.data.JSONPerformance) {
+    let performanceData = JSON.parse(event.data.JSONPerformance);
+    console.log("iframe received a port message", performanceData);
+    document.querySelector("pre").innerHTML = JSON.stringify(performanceData, null, 2);
   }
-});
+};
 
-chrome.runtime.onMessage.addListener(function (msg) {
-  console.log(msg)
-});
+document.querySelector("#scan").onclick = () => {
+  console.log("CLICKED scan");
+  port1.postMessage("scan");
+};
+
+window.parent.postMessage("connect-perfomance-toolbar", "*", [port2]);


### PR DESCRIPTION
The tab (or the content script) and webextension iframe can exchange messages using the [MessageChannel WebAPI](https://developer.mozilla.org/en-US/docs/Web/API/MessageChannel).

Data exchanged between the two contexts needs to be "trasferable" (e.g. MessageChannel ports) or needs to be manually converted into JSON serializable object.
